### PR TITLE
Enable auto-merge for pre-commit.ci PRs

### DIFF
--- a/.github/workflows/auto-merge-precommit.yml
+++ b/.github/workflows/auto-merge-precommit.yml
@@ -1,0 +1,22 @@
+name: Auto-merge pre-commit.ci PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    if: github.event.pull_request.user.login == 'pre-commit-ci[bot]' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge (squash)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --squash


### PR DESCRIPTION
Adds a workflow that enables GitHub auto-merge for PRs opened by pre-commit-ci[bot]. The PR will merge only after required checks pass.